### PR TITLE
add staging deployment and slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Toward proactively encouraging cloud.gov customers to restage their apps so they can benefit from buildpack updates.
 
-## Deploying
+## Deploying With Concourse
+
+Prior to deploying with Concourse, you need to setup services and get the credentials.
+
+### Database Setup
+
+Create a PostgreSQL database: `cf cs aws-rds shared-psql buildpack-notify-db`
+
+### Service Deployer Account
+
+Follow the instructions in our [docs](https://cloud.gov/docs/services/cloud-gov-service-account/) to
+get credentials for a deployer service named `buildpack-notify-deployer`.
 
 ### User Provided Services
 
@@ -10,11 +21,13 @@ You need to copy the `*.example.json` credential files into `*.json` files.
 Fill them out then run the following commands:
 
 ```sh
-cf cups notify-email-creds -l cf/notify_email_creds.json
-cf cups notify-cf-creds -l cf/notify_cf_creds.json
+cf cups notify-email-creds -p cf/notify_email_creds.json
+cf cups notify-cf-creds -p cf/notify_cf_creds.json
 ```
 
-## Running `cf run-task`
+## Running `cf run-task` locally
+
+Note: You don't need to do this because Concourse will do this for you once the pipeline is set.
 
 After the service is deployed, run:
 

--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -1,22 +1,20 @@
-smtp-from: no-reply@cloud.gov
-smtp-port: 587
-smtp-pass:
-smtp-user:
-smtp-host:
-cf-api-prod: https://api.fr.cloud.gov
-cf-org-prod: cloud.gov
-cf-space-prod: customer-prod
-client-id-prod:
-client-secret-prod:
+cf-api-production: https://api.fr.cloud.gov
+cf-org-production: cloud.gov
+cf-space-production: customer-prod
 cf-api-staging: https://api.fr-stage.cloud.gov
 cf-org-staging:
 cf-space-staging:
-client-id-staging:
-client-secret-staging:
 cg-buildpack-notify: https://github.com/18F/cg-buildpack-notify.git
 cg-buildpack-notify-branch: master
-deployer-username-prod:
-deployer-password-prod:
-additional-args:
+deployer-username-production:
+deployer-password-production:
+deployer-username-staging:
+deployer-password-staging:
+additional-args-production:
+additional-args-staging:
 cg-buildpack-notify-github-repo-name: 18F/cg-buildpack-notify
 status-access-token:
+slack-webhook-url:
+slack-channel:
+slack-username:
+slack-icon-url:

--- a/ci/notify.sh
+++ b/ci/notify.sh
@@ -1,7 +1,43 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -x
 
 cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION -s $CF_SPACE
 
-cf run-task cg-buildpack-notify "bin/cg-buildpack-notify -notify $ADDITIONAL_ARGS"
+# Currently the output looks like this from the `run-task` cmd.
+# cf run-task cg-buildpack-notify "bin/cg-buildpack-notify -notify -dry-run"
+# Creating task for app cg-buildpack-notify in org my-org / space my-space as username...
+# OK
+#
+# Task has been submitted successfully for execution.
+# task name:   deadbeef
+# task id:     1234
+output=$(cf run-task cg-buildpack-notify "bin/cg-buildpack-notify -notify $ADDITIONAL_ARGS")
+
+# Let's get the task id and task name.
+task_id=$(echo "${output}" | grep -i "task id" | awk '{print $NF}')
+task_name=$(echo "${output}" | grep -i "task name" | awk '{print $NF}')
+
+# Keep waiting until the task is no longer in RUNNING state
+# note: the first grep checks for task_id at the start of the line because the random generated task name SHA
+# may also contain part of the id and it could be for another task.
+elapsed=300
+while [ "${elapsed}" -gt 0 ]; do
+  if cf tasks cg-buildpack-notify | grep "^$task_id" | grep -qv "RUNNING"; then
+    # if the task is no longer running, exit loop.
+    break
+  fi
+  let elapsed-=5
+  sleep 5
+done
+# note: if the loop ends, the script will end because of the `set -e` flag.
+
+# print the logs
+cf logs cg-buildpack-notify --recent | grep $task_name
+
+if cf tasks cg-buildpack-notify | grep "^$task_id" | grep -q "FAILED"; then
+  echo "task failed to complete."
+  exit 1
+fi
+
+echo "task finished successfully"

--- a/ci/notify.yml
+++ b/ci/notify.yml
@@ -9,16 +9,9 @@ inputs:
 run:
   path: gopath/src/github.com/18F/cg-buildpack-notify/ci/notify.sh
 params:
-  SMTP_FROM:
-  SMTP_PORT:
-  SMTP_PASS:
-  SMTP_USER:
-  SMTP_HOST:
   CF_API:
   CF_ORGANIZATION:
   CF_SPACE:
   CF_USERNAME:
   CF_PASSWORD:
-  CLIENT_ID:
-  CLIENT_SECRET:
   ADDITIONAL_ARGS:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,10 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
 
 - name: pull-request
   type: docker-image
@@ -18,20 +22,32 @@ resources:
   source:
     uri: ((cg-buildpack-notify))
     branch: ((cg-buildpack-notify-branch))
+- name: cg-buildpack-notify-deploy-staging
+  type: cf
+  source:
+    api: ((cf-api-staging))
+    username: ((deployer-username-staging))
+    password: ((deployer-password-staging))
+    organization: ((cf-org-staging))
+    space: ((cf-space-staging))
 - name: cg-buildpack-notify-deploy-production
   type: cf
   source:
-    api: ((cf-api-prod))
-    username: ((deployer-username-prod))
-    password: ((deployer-password-prod))
-    organization: ((cf-org-prod))
-    space: ((cf-space-prod))
+    api: ((cf-api-production))
+    username: ((deployer-username-production))
+    password: ((deployer-password-production))
+    organization: ((cf-org-production))
+    space: ((cf-space-production))
 - name: pull-request
   type: pull-request
   source:
     repo: ((cg-buildpack-notify-github-repo-name))
     access_token: ((status-access-token))
     every: true
+- name: slack
+  type: slack-notification
+  source:
+    url: ((slack-webhook-url))
 
 jobs:
 - name: pull-status-check
@@ -63,17 +79,63 @@ jobs:
     trigger: true
   - task: run-tests
     file: notify-src/ci/run-tests.yml
-- name: push-cg-buildpack-notify-production
+- name: push-cg-buildpack-notify-staging
   plan:
   - aggregate:
     - get: notify-src
       passed: [test-cg-buildpack-notify]
       trigger: true
+  - put: cg-buildpack-notify-deploy-staging
+    params:
+      path: notify-src
+      manifest: notify-src/manifest.yml
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to deploy buildpack-notifier on ((cf-api-staging))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+  on_success:
+    put: slack
+    params:
+      text: |
+        :white_check_mark: Successfully deployed buildpack-notifier on ((cf-api-staging))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+- name: push-cg-buildpack-notify-production
+  plan:
+  - aggregate:
+    - get: notify-src
+      passed: [push-cg-buildpack-notify-staging]
+      trigger: true
   - put: cg-buildpack-notify-deploy-production
     params:
       path: notify-src
       manifest: notify-src/manifest.yml
-- name: notify-customers-prod
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to deploy buildpack-notifier on ((cf-api-production))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+  on_success:
+    put: slack
+    params:
+      text: |
+        :white_check_mark: Successfully deployed buildpack-notifier on ((cf-api-production))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+- name: notify-customers-staging
   plan:
   - get: check-buildpack-updates
     trigger: true
@@ -81,16 +143,42 @@ jobs:
   - task: do-notify
     file: notify-src/ci/notify.yml
     params:
-      SMTP_FROM: ((smtp-from))
-      SMTP_PORT: ((smtp-port))
-      SMTP_PASS: ((smtp-pass))
-      SMTP_USER: ((smtp-user))
-      SMTP_HOST: ((smtp-host))
-      CF_API: ((cf-api-prod))
-      CF_ORGANIZATION: ((cf-org-prod))
-      CF_SPACE: ((cf-space-prod))
-      CF_USERNAME: ((deployer-username-prod))
-      CF_PASSWORD: ((deployer-password-prod))
-      CLIENT_ID: ((client-id-prod))
-      CLIENT_SECRET: ((client-secret-prod))
-      ADDITIONAL_ARGS: ((additional-args))
+      CF_API: ((cf-api-staging))
+      CF_ORGANIZATION: ((cf-org-staging))
+      CF_SPACE: ((cf-space-staging))
+      CF_USERNAME: ((deployer-username-staging))
+      CF_PASSWORD: ((deployer-password-staging))
+      ADDITIONAL_ARGS: ((additional-args-staging))
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to notify customers with buildpack-notifier on ((cf-api-staging))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: notify-customers-production
+  plan:
+  - get: check-buildpack-updates
+    trigger: true
+  - get: notify-src
+  - task: do-notify
+    file: notify-src/ci/notify.yml
+    params:
+      CF_API: ((cf-api-production))
+      CF_ORGANIZATION: ((cf-org-production))
+      CF_SPACE: ((cf-space-production))
+      CF_USERNAME: ((deployer-username-production))
+      CF_PASSWORD: ((deployer-password-production))
+      ADDITIONAL_ARGS: ((additional-args-production))
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to notify customers with buildpack-notifier on ((cf-api-production))
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))


### PR DESCRIPTION
this commit puts a staging deployment before the production deployment

add slack notifications for success / fail deploys

add slack notifications for fail notifications run-tasks

other misc changes:
`prod` -> `production`
create more staging vs production variables for the pipeline